### PR TITLE
examples: iotg-yocto-ese: allocate 2MB-hugepages by default

### DIFF
--- a/examples/iotg-yocto-ese/local.conf
+++ b/examples/iotg-yocto-ese/local.conf
@@ -33,10 +33,10 @@ IMAGE_INSTALL:append = " \
     efibootmgr \
     htop \
     lmsensors \
-    pciutils \
-    python3-pip \
-    perf \
     opae-sdk \
+    pciutils \
+    perf \
+    python3-pip \
     rsync \
     usbutils \
 "


### PR DESCRIPTION
This resolves running the host_exerciser sample which allocates two buffers backed by a 2MB hugepage each.

https://github.com/OFS/opae-sdk/blob/8dbe1c3f8df0747538d6153684f0d6740994176b/samples/host_exerciser/host_exerciser_cmd.h#L785-L801