### PR TITLE
Update manifest.xml

### DIFF
--- a/examples/iotg-yocto-ese/manifest.xml
+++ b/examples/iotg-yocto-ese/manifest.xml
@@ -17,25 +17,25 @@
   <project name="openembedded-core"
            remote="git.openembedded.org"
            path="intel-embedded-system-enabling"
-           revision="717b9f18a51e9c9fd5a471238aa2ea4de439ef17" />
+           revision="08ab1f02da65ee9815115e6a1cdb51ffed10a2dc" />
 
   <!-- https://git.openembedded.org/meta-openembedded/log/?h=kirkstone -->
   <project name="meta-openembedded"
            remote="git.openembedded.org"
            path="intel-embedded-system-enabling/meta-openembedded"
-           revision="5f120a926b0fcd55cfe7565bb7ddf23661cad498" />
+           revision="571e36e20e9d1f27af0eb4545291beeb64f280e2" />
 
   <!-- https://git.openembedded.org/bitbake/log/?h=2.0 -->
   <project name="bitbake"
            remote="git.openembedded.org"
            path="intel-embedded-system-enabling/bitbake"
-           revision="0c6f86b60cfba67c20733516957c0a654eb2b44c" />
+           revision="9bbdedc0ba7ca819b898e2a29a151d6a2014ca11" />
 
   <!-- https://git.yoctoproject.org/meta-intel/log/?h=kirkstone -->
   <project name="meta-intel"
            remote="git.yoctoproject.org"
            path="intel-embedded-system-enabling/meta-intel"
-           revision="eb696e99ff8c5be4f9b181da9f134499d96760e4" />
+           revision="4c6cc14669d0e9de36e1a050ce4084ca14181722" />
 
   <project name="intel/iotg-yocto-ese-main"
            remote="github.com"


### PR DESCRIPTION
Changing manifest back to previous tags that aligned to last tested Kirkstone release. 
Effectively undoing this change: https://github.com/OFS/meta-ofs/commit/d956bed0390003e3ae2acfbc76846ac2101739b7 