### PR TITLE
opae-sdk: resolve FTBFS due to missing libnuma

### DIFF
--- a/recipes-ofs/opae-sdk/opae-sdk_git.bb
+++ b/recipes-ofs/opae-sdk/opae-sdk_git.bb
@@ -11,6 +11,7 @@ DEPENDS = "\
     hwloc \
     json-c \
     libedit \
+    numactl \
     python3 \
     python3-jsonschema-native \
     python3-pip-native \


### PR DESCRIPTION
This resolves a failure to build OPAE SDK commit [d6fc9b25](https://github.com/OFS/opae-sdk/commit/d6fc9b25cef76dbb58b02574794a6c178dd3df75) ("Feature: Add CXL host exerciser cache application (#3009)") which requires libnuma to build the cxl_host_exerciser sample.