### PR TITLE
linux: update revision for OFS 2023.3 RC2

### DIFF
--- a/recipes-kernel/linux/linux-intel-iot-lts-6.1_git.bbappend
+++ b/recipes-kernel/linux/linux-intel-iot-lts-6.1_git.bbappend
@@ -2,7 +2,7 @@ KBRANCH = "fpga-ofs-dev-6.1-lts"
 KERNEL_SRC_URI = "git://github.com/OFS/linux-dfl;protocol=https;branch=${KBRANCH};name=machine"
 SRC_URI = "${KERNEL_SRC_URI}"
 SRCREV_meta = "${AUTOREV}"
-SRCREV_machine = "6f8977498ae390a61a5d83ad7d87a041fdef2b06"
+SRCREV_machine = "f34a2d519aa955a7f36dbf418f6c3e9cc11eca4a"
 LINUX_VERSION = "6.1"
 LINUX_VERSION_EXTENSION = "-dfl-${@bb.fetch2.get_srcrev(d).split('_')[1]}"
 


### PR DESCRIPTION
### Description
Update the linux-dfl version to correspond with the linux-dfl 2023.3 RC2


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
