### PR TITLE
[Update] Update linux and opae-sdk commits for RC2

### DIFF
--- a/recipes-kernel/linux/linux-intel-iot-lts-6.1_git.bbappend
+++ b/recipes-kernel/linux/linux-intel-iot-lts-6.1_git.bbappend
@@ -2,7 +2,7 @@ KBRANCH = "fpga-ofs-dev-6.1-lts"
 KERNEL_SRC_URI = "git://github.com/OFS/linux-dfl;protocol=https;branch=${KBRANCH};name=machine"
 SRC_URI = "${KERNEL_SRC_URI}"
 SRCREV_meta = "${AUTOREV}"
-SRCREV_machine = "ba2f178179b59dda22134ed6f4a162bf07b30be9"
+SRCREV_machine = "6b0d820d436dda1e5949205a8f081fe0360c8430"
 LINUX_VERSION = "6.1"
 LINUX_VERSION_EXTENSION = "-dfl-${@bb.fetch2.get_srcrev(d).split('_')[1]}"
 

--- a/recipes-ofs/opae-sdk/opae-sdk_git.bb
+++ b/recipes-ofs/opae-sdk/opae-sdk_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/OFS/opae-sdk"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5351f05d1aa340cb91bb885c2fd82fc7"
 SRC_URI = "git://github.com/OFS/opae-sdk;protocol=https;branch=release/2.12.0"
-SRCREV = "b2a529706f23ecd9387e54e1d6ba016a287a82b3"
+SRCREV = "e9e9ac8fcdce89dddfcae645448eb37321033132"
 S = "${WORKDIR}/git"
 
 DEPENDS = "\


### PR DESCRIPTION
### Description
Update the commits used to build opae-sdk and the linux-dfl kernel to those being used in the respective repos for OFS-2024.1 RC2.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Image builds successfully